### PR TITLE
Replace ';' with '&&' in RUN command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY wine_cfg /wine_configs/default
 
 # Copy the code over and extract
 COPY superfish.tar.gz /
-RUN tar -xzf superfish.tar.gz; rm -rf superfish.tar.gz
+RUN tar -xzf superfish.tar.gz && rm -rf superfish.tar.gz
 
 # Create unix alias for wine commands for superfish
 RUN /bin/bash -c 'for app in $(ls /PoissonSuperfish/*.EXE); \


### PR DESCRIPTION
In the Dockerfile, this replaces ; with && in the line
`RUN tar -xzf superfish.tar.gz && rm -rf superfish.tar.gz`

This way if that tar fails, docker will halt the build process.

We ran into this issue recently with a file `superfish.tar.gz` which was actually only tarred, not gzipped.
The build appeared to succeed, but then didn't work, because the tar step had silently failed so none of the executables had been copied. 

With this proposed change, it would instead halt with an error like:
```
 => [ 6/20] COPY superfish.tar.gz /                                                            0.7s
 => ERROR [ 7/20] RUN tar -xzf superfish.tar.gz && rm -rf superfish.tar.gz                     0.4s
------
 > [ 7/20] RUN tar -xzf superfish.tar.gz && rm -rf superfish.tar.gz:
0.340
0.340 gzip: stdin: not in gzip format
0.340 tar: Child returned status 1
0.340 tar: Error is not recoverable: exiting now
------
Dockerfile:30
--------------------
  28 |     # Copy the code over and extract
  29 |     COPY superfish.tar.gz /
  30 | >>> RUN tar -xzf superfish.tar.gz && rm -rf superfish.tar.gz
  31 |
  32 |     # Create unix alias for wine commands for superfish
--------------------
ERROR: failed to solve: process "/bin/sh -c tar -xzf superfish.tar.gz && rm -rf superfish.tar.gz" did not complete successfully: exit code: 2
```